### PR TITLE
Update Jedis to 3.1.0-m4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <assertj.version>3.12.2</assertj.version>
         <embedded-redis.version>0.6</embedded-redis.version>
         <guava.version>27.1-jre</guava.version>
-        <jedis.version>3.1.0-m1</jedis.version>
+        <jedis.version>3.1.0-m4</jedis.version>
         <jsr166e.version>1.1.0</jsr166e.version>
         <junit.version>4.13-beta-3</junit.version>
         <log4j2.version>2.11.2</log4j2.version>


### PR DESCRIPTION
Includes a version bump of `commons-pool2`, which fixes an issue with the thread pool, see also: https://github.com/xetorthio/jedis/pull/2012